### PR TITLE
bs/kt - course contrast

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,4 +15,9 @@ body {
   .color-nav{
     background-color: rgb(0, 54, 96);
   } 
+
+  .btn-primary{
+    background-color: #34859b;
+    border-color: #34859b;
+  } 
   

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,4 +20,8 @@ body {
     background-color: #34859b;
     border-color: #34859b;
   } 
-  
+
+  .btn-primary:hover{
+    background-color: #34859b;
+    border-color: #34859b;
+  } 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,4 +11,8 @@ body {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
       monospace;
   }
+
+  .color-nav{
+    background-color: rgb(0, 54, 96);
+  } 
   

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -13,7 +13,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
           <AppNavbarLocalhost url={currentUrl} />
         )
       }
-      <Navbar expand="xl" variant="dark" bg="dark" sticky="top" data-testid="AppNavbar">
+      <Navbar expand="xl" variant="dark" className="color-nav" sticky="top" data-testid="AppNavbar">
         <Container >
         <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginRight: 10}} />
           <Navbar.Brand as={Link} to="/">

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -36,7 +36,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
             {
               systemInfo?.springH2ConsoleEnabled && (
                 <>
-                  <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                  <Nav.Link href="/h2-console">H2Console </Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -38,7 +38,7 @@ export default function SectionsOverTimeTableBase({ columns, data, testid = "tes
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                     // Stryker disable next-line ObjectLiteral
-                    style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? "#003660" : cell.isAggregated ? "#003660" : "#7490a6", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     
                     {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -38,7 +38,7 @@ export default function SectionsOverTimeTableBase({ columns, data, testid = "tes
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                     // Stryker disable next-line ObjectLiteral
-                    style={{background: cell.isGrouped ? "#003660" : cell.isAggregated ? "#003660" : "#7490a6", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? "#34859b" : cell.isAggregated ? "#34859b" : "#9dbfbe", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     
                     {cell.isGrouped ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -38,7 +38,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                     // Stryker disable next-line ObjectLiteral
-                    style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? "#34859b" : cell.isAggregated ? "#34859b" : "#9dbfbe", color: cell.isGrouped ? "#effcf4" : cell.isAggregated ? "#effcf4" : "#000000", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     
                     {cell.isGrouped ? (


### PR DESCRIPTION
In this PR, we changed the color of submit, login, and logout buttons to match the UCSB standard teal blue, including when hovering and clicking. We also changed the course history table and the main page section search to match the UCSB standard teal blue. 

Before: 
![Screen Shot 2023-05-30 at 2 06 31 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/f4a748fc-ce6c-414e-8f84-5e59d8e4c5f5)
![Screen Shot 2023-05-31 at 7 21 17 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/6ef82043-ba5b-43d7-90c3-055874548264)
![Screen Shot 2023-05-31 at 7 27 13 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/ac8dc906-6b79-4880-a1f9-01876cc1a50f)

After:
![Screen Shot 2023-05-31 at 7 19 13 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/a3ca4b15-91d2-4f96-a43b-e5ed684d131f)
![Screen Shot 2023-05-31 at 7 20 57 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/254eb70f-490a-4ea2-b5e9-330ad6ee55e9)
![Screen Shot 2023-05-31 at 7 27 53 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/9a352ecf-4aed-4d78-b223-bb67bba47aef)

Storybook link: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-4/storybook/?path=/docs/components-courses-basiccoursetable--empty

Closes: #10 