### PR TITLE
bs - add course number search option to course description search (frontend & backend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Users with a Google Account can also store past, current or future schedules of 
 
 | Type | Link       | 
 |------|------------|
-| prod | <https://proj-courses.dokku-12.cs.ucsb.edu/> | 
-| qa | <https://proj-courses-qa.dokku-12.cs.ucsb.edu/>  | 
+| prod | <https://proj-courses.dokku-00.cs.ucsb.edu/> | 
+| qa | <https://proj-courses-qa.dokku-00.cs.ucsb.edu/>  | 
 
 
 # Setup before running application

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -25,7 +25,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const localSubject = localStorage.getItem("BasicSearch.Subject");
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
-  const localCourseNumber = localStorage.getItem("CourseOverTimeSearch.CourseNumber");
+  const localCourseNumber = localStorage.getItem("BasicSearch.CourseNumber");
 
   const { data: subjects, error: _error, status: _status } =
   useBackend(
@@ -93,7 +93,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
             />
           </Col>
         </Row>
-        <Form.Group controlId="CourseOverTimeSearch.CourseNumber">
+        <Form.Group controlId="BasicSearch.CourseNumber">
             <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
             <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />
         </Form.Group>

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -25,6 +25,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const localSubject = localStorage.getItem("BasicSearch.Subject");
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
   const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
+  const localCourseNumber = localStorage.getItem("CourseOverTimeSearch.CourseNumber");
 
   const { data: subjects, error: _error, status: _status } =
   useBackend(
@@ -37,10 +38,29 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
   const [level, setLevel] = useState(localLevel || "U");
+  const [courseNumber, setCourseNumber] = useState(localCourseNumber || "");
+  const [courseSuf, setCourseSuf] = useState("");
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchJSON(event, { quarter, subject, level });
+    fetchJSON(event, { quarter, subject, level, courseNumber, courseSuf });
+  };
+
+  const handleCourseNumberOnChange = (event) => {
+    const rawCourse = event.target.value;
+    if (rawCourse.match(/\d+/g) != null) {
+        const number = rawCourse.match(/\d+/g)[0];
+        setCourseNumber(number);
+    } else {
+        setCourseNumber("");
+    }
+    
+    if (rawCourse.match(/[a-zA-Z]+/g) != null) {
+        const suffix = rawCourse.match(/[a-zA-Z]+/g)[0];
+        setCourseSuf(suffix);
+    } else {
+        setCourseSuf("");
+    }
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
@@ -73,6 +93,10 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
             />
           </Col>
         </Row>
+        <Form.Group controlId="CourseOverTimeSearch.CourseNumber">
+            <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
+            <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />
+        </Form.Group>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
             <Button variant="primary" type="submit">

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -94,7 +94,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
           </Col>
         </Row>
         <Form.Group controlId="BasicSearch.CourseNumber">
-            <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
+            <Form.Label>Course Number (Try searching '16' or '130A', or leave blank to view all courses)</Form.Label>
             <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />
         </Form.Group>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -8,7 +8,7 @@ import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
-import { useBackend  } from "main/utils/useBackend";
+import { useBackend } from "main/utils/useBackend";
 
 const BasicCourseSearchForm = ({ fetchJSON }) => {
 

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -94,7 +94,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
           </Col>
         </Row>
         <Form.Group controlId="BasicSearch.CourseNumber">
-            <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
+            <Form.Label>Course Number</Form.Label>
             <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />
         </Form.Group>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -94,7 +94,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
           </Col>
         </Row>
         <Form.Group controlId="BasicSearch.CourseNumber">
-            <Form.Label>Course Number</Form.Label>
+            <Form.Label>Course Number (Try searching '16' or '130A')</Form.Label>
             <Form.Control onChange={handleCourseNumberOnChange} defaultValue={courseNumber} />
         </Form.Group>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -63,7 +63,6 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
     }
   };
 
-  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -61,7 +61,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
     } else {
         setCourseSuf("");
     }
-};
+  };
 
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -63,8 +63,6 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
     }
   };
 
-
-  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -8,7 +8,7 @@ import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
 import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 //import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
-import { useBackend  } from "main/utils/useBackend";
+import { useBackend } from "main/utils/useBackend";
 
 const CourseOverTimeSearchForm = ({ fetchJSON }) => {
 

--- a/frontend/src/main/components/Courses/BasicCourseTable.js
+++ b/frontend/src/main/components/Courses/BasicCourseTable.js
@@ -3,6 +3,14 @@ import OurTable from "main/components/OurTable";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
+function getFirstVal(values) {
+    return values[0];
+};
+
+function getCourseId(courseIds) {
+    return courseIds[0].substring(0, courseIds[0].length - 2);
+}
+
 export default function BasicCourseTable({ courses }) {
 
     const columns = [
@@ -13,11 +21,19 @@ export default function BasicCourseTable({ courses }) {
         },
         {
             Header: 'Course Id',
-            accessor: 'courseId',
+            accessor: 'courseInfo.courseId',
+
+            aggregate: getCourseId,
+            Aggregated: ({ cell: { value } }) => `${value}`,
+
+            Cell: ({ cell: { value } }) => value.substring(0, value.length - 2)
         },
         {
             Header: 'Title',
             accessor: 'title',
+
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Description',

--- a/frontend/src/main/components/Courses/BasicCourseTable.js
+++ b/frontend/src/main/components/Courses/BasicCourseTable.js
@@ -3,16 +3,8 @@ import OurTable from "main/components/OurTable";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
-function getFirstVal(values) {
-    return values[0];
-};
-
-function getCourseId(courseIds) {
-    return courseIds[0].substring(0, courseIds[0].length - 2);
-}
-
 export default function BasicCourseTable({ courses }) {
-
+    console.log(courses);
     const columns = [
         {
             Header: 'Quarter',
@@ -21,19 +13,11 @@ export default function BasicCourseTable({ courses }) {
         },
         {
             Header: 'Course Id',
-            accessor: 'courseInfo.courseId',
-
-            aggregate: getCourseId,
-            Aggregated: ({ cell: { value } }) => `${value}`,
-
-            Cell: ({ cell: { value } }) => value.substring(0, value.length - 2)
+            accessor: 'courseId',
         },
         {
             Header: 'Title',
             accessor: 'title',
-
-            aggregate: getFirstVal,
-            Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
             Header: 'Description',

--- a/frontend/src/main/components/Courses/BasicCourseTable.js
+++ b/frontend/src/main/components/Courses/BasicCourseTable.js
@@ -4,7 +4,6 @@ import OurTable from "main/components/OurTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 export default function BasicCourseTable({ courses }) {
-    console.log(courses);
     const columns = [
         {
             Header: 'Quarter',

--- a/frontend/src/main/pages/CourseDescriptions/CourseDescriptionIndexPage.js
+++ b/frontend/src/main/pages/CourseDescriptions/CourseDescriptionIndexPage.js
@@ -36,7 +36,7 @@ export default function CourseDescriptionIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h5>Welcome to the UCSB Courses Description Search!</h5>
+        <h5>Welcome to the UCSB Course Description Search!</h5>
         <BasicCourseSearchForm fetchJSON={fetchBasicCourseJSON} />
         <BasicCourseTable courses={courseJSON} />
       </div>

--- a/frontend/src/main/pages/CourseDescriptions/CourseDescriptionIndexPage.js
+++ b/frontend/src/main/pages/CourseDescriptions/CourseDescriptionIndexPage.js
@@ -14,6 +14,7 @@ export default function CourseDescriptionIndexPage() {
       qtr: query.quarter,
       dept: query.subject,
       level: query.level,
+      courseNumber: query.courseNumber + query.courseSuf,
     },
   });
 

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -138,8 +138,8 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const selectCourseNum = screen.getByLabelText("Course Number");
-    userEvent.selectOptions(selectCourseNum, "5");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNum, "5");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
 
@@ -180,8 +180,8 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "MATH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const selectCourseNum = screen.getByLabelText("Course Number");
-    userEvent.selectOptions(selectCourseNum, "");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNum, "");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
   });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -110,7 +110,7 @@ describe("BasicCourseSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNumber, "24");
     expect(selectCourseNumber.value).toBe("24");
   });
@@ -123,7 +123,7 @@ describe("BasicCourseSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNumber, "130A");
     expect(selectCourseNumber.value).toBe("130A");
   });
@@ -136,7 +136,7 @@ describe("BasicCourseSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNumber, "A");
     expect(selectCourseNumber.value).toBe("A");
   });
@@ -177,7 +177,7 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNum, "5");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
@@ -219,7 +219,7 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "MATH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNum, "");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -124,6 +124,8 @@ describe("BasicCourseSearchForm tests", () => {
       quarter: "20211",
       subject: "ANTH",
       level: "G",
+      courseNumber:"5",
+      courseSuf:""
     };
 
     const expectedKey = "BasicSearch.Subject-option-ANTH";

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -180,6 +180,8 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "MATH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
+    const selectCourseNum = screen.getByLabelText("Course Number");
+    userEvent.selectOptions(selectCourseNum, "");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
   });

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -138,6 +138,8 @@ describe("BasicCourseSearchForm tests", () => {
     userEvent.selectOptions(selectSubject, "ANTH");
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
+    const selectCourseNum = screen.getByLabelText("Course Number");
+    userEvent.selectOptions(selectCourseNum, "5");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
 

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -102,6 +102,45 @@ describe("BasicCourseSearchForm tests", () => {
     expect(selectLevel.value).toBe("G");
   });
 
+  test("when I select a course number without suffix, the state for course number changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNumber, "24");
+    expect(selectCourseNumber.value).toBe("24");
+  });
+
+  test("when I select a course number with suffix, the state for course number changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNumber, "130A");
+    expect(selectCourseNumber.value).toBe("130A");
+  });
+
+  test("when I select a course number without number, the state for course number changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectCourseNumber = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNumber, "A");
+    expect(selectCourseNumber.value).toBe("A");
+  });
+
   test("when I click submit, the right stuff happens", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
     const sampleReturnValue = {

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -56,6 +56,20 @@ describe("BasicCourseSearchForm tests", () => {
     );
   });
 
+  test("expected CSS property of submit button", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BasicCourseSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toHaveAttribute("style", "paddingTop: 10, paddingBottom: 10");
+
+  });
+
   test("when I select a quarter, the state for quarter changes", () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -56,6 +56,20 @@ describe("CourseOverTimeSearchForm tests", () => {
     );
   });
 
+  test("expected CSS property of submit button", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toHaveAttribute("style", "paddingTop: 10, paddingBottom: 10");
+
+  });
+
   test("when I select a start quarter, the state for start quarter changes", () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
@@ -81,8 +81,8 @@ describe("CourseDescriptionIndexPage tests", () => {
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
 
-    const selectCourseNum = screen.getByLabelText("Course Number");
-    userEvent.selectOptions(selectCourseNum, "5");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    userEvent.type(selectCourseNum, "5");
 
     const submitButton = screen.getByText("Submit");
     expect(submitButton).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe("CourseDescriptionIndexPage tests", () => {
       qtr: "20211",
       dept: "ANTH",
       level: "G",
-      courseNum: "5"
+      courseNumber: "5"
     });
 
     expect(screen.getByText("CMPSC")).toBeInTheDocument();

--- a/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
@@ -81,6 +81,9 @@ describe("CourseDescriptionIndexPage tests", () => {
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
 
+    const selectCourseNum = screen.getByLabelText("Course Number");
+    userEvent.selectOptions(selectCourseNum, "5");
+
     const submitButton = screen.getByText("Submit");
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
@@ -95,6 +98,7 @@ describe("CourseDescriptionIndexPage tests", () => {
       qtr: "20211",
       dept: "ANTH",
       level: "G",
+      courseNum: "5"
     });
 
     expect(screen.getByText("CMPSC")).toBeInTheDocument();

--- a/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDescriptions/CourseDescriptionIndexPage.test.js
@@ -81,7 +81,7 @@ describe("CourseDescriptionIndexPage tests", () => {
     const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
 
-    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A')");
+    const selectCourseNum = screen.getByLabelText("Course Number (Try searching '16' or '130A', or leave blank to view all courses)");
     userEvent.type(selectCourseNum, "5");
 
     const submitButton = screen.getByText("Submit");

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -38,7 +38,7 @@ public class UCSBCurriculumController {
         @RequestParam String courseNumber
         ) throws JsonProcessingException {
 
-        String body = ucsbCurriculumService.getJSON(dept, qtr, level, courseNumber);
+        String body = ucsbCurriculumService.getJSONCourseDescription(dept, qtr, level, courseNumber);
         
         return ResponseEntity.ok().body(body);
     }      

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -31,11 +31,31 @@ public class UCSBCurriculumController {
     UCSBCurriculumService ucsbCurriculumService;
 
     @GetMapping(value = "/basicsearch", produces = "application/json")
-    public ResponseEntity<String> basicsearch(@RequestParam String qtr, @RequestParam String dept,
-            @RequestParam String level) throws JsonProcessingException {
+    public ResponseEntity<String> basicsearch(
+        @RequestParam String qtr, 
+        @RequestParam String dept,
+        @RequestParam String level,
+        @RequestParam String courseNumber
+        ) throws JsonProcessingException {
 
-        String body = ucsbCurriculumService.getJSON(dept, qtr, level);
+        String body = ucsbCurriculumService.getJSON(dept, qtr, level, makeFormattedCourseId(dept, courseNumber));
         
         return ResponseEntity.ok().body(body);
     }      
+
+    String makeFormattedCourseId(String dept, String courseNumber) {
+        String[] nums = courseNumber.split("[a-zA-Z]+");
+        String[] suffs = courseNumber.split("[0-9]+");
+        if (suffs.length < 2) { // no suffix
+            return
+                  String.format( "%-8s", dept                ) // 'CMPSC   '
+                + String.format( "%3s" , nums[0]                    ) // '  8'
+            ;
+        }
+        return
+              String.format( "%-8s", dept                ) // 'CMPSC   '
+            + String.format( "%3s" , nums[0]                    ) // '  8'
+            + String.format( "%-2s", suffs[1]                   ) // 'A '
+        ;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -38,24 +38,8 @@ public class UCSBCurriculumController {
         @RequestParam String courseNumber
         ) throws JsonProcessingException {
 
-        String body = ucsbCurriculumService.getJSON(dept, qtr, level, makeFormattedCourseId(dept, courseNumber));
+        String body = ucsbCurriculumService.getJSON(dept, qtr, level, courseNumber);
         
         return ResponseEntity.ok().body(body);
     }      
-
-    String makeFormattedCourseId(String dept, String courseNumber) {
-        String[] nums = courseNumber.split("[a-zA-Z]+");
-        String[] suffs = courseNumber.split("[0-9]+");
-        if (suffs.length < 2) { // no suffix
-            return
-                  String.format( "%-8s", dept                ) // 'CMPSC   '
-                + String.format( "%3s" , nums[0]                    ) // '  8'
-            ;
-        }
-        return
-              String.format( "%-8s", dept                ) // 'CMPSC   '
-            + String.format( "%3s" , nums[0]                    ) // '  8'
-            + String.format( "%-2s", suffs[1]                   ) // 'A '
-        ;
-    }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -90,16 +90,34 @@ public class UCSBCurriculumService {
 
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
-        String params = String.format(
+        String url = null;
+
+        // if (courseId.equals("")){
+        if (courseNumber.equals("")){
+            String params = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, courseLevel, 1, 100, "true");
+            url = CURRICULUM_ENDPOINT + params;
+
+            if (courseLevel.equals("A")) {
+                params = String.format(
+                        "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                        quarter, subjectArea, 1, 100, "true");
+                url = CURRICULUM_ENDPOINT + params;
+            }
+        }
+
+        else{
+            String params = String.format(
                 "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
                 subjectArea, courseLevel, courseId, 1, 100, "true");
-        String url = CURRICULUM_ENDPOINT + params;
-
-        if (courseLevel.equals("A")) {
-            params = String.format(
-                    "?quarter=%s&subjectCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
-                    quarter, subjectArea, courseId, 1, 100, "true");
             url = CURRICULUM_ENDPOINT + params;
+            if (courseLevel.equals("A")) {
+                params = String.format(
+                        "?quarter=%s&subjectCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                        quarter, subjectArea, courseId, 1, 100, "true");
+                url = CURRICULUM_ENDPOINT + params;
+        }
         }
 
         log.info("url=" + url);

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -80,6 +80,8 @@ public class UCSBCurriculumService {
 
     public String getJSON(String subjectArea, String quarter, String courseLevel, String courseNumber) {
 
+        String courseId = makeFormattedCourseId(subjectArea, courseNumber);
+
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -89,14 +91,14 @@ public class UCSBCurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String params = String.format(
-                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseNumber=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
-                subjectArea, courseLevel, courseNumber, 1, 100, "true");
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, courseLevel, courseId, 1, 100, "true");
         String url = CURRICULUM_ENDPOINT + params;
 
         if (courseLevel.equals("A")) {
             params = String.format(
-                    "?quarter=%s&subjectCode=%s&courseNumber=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
-                    quarter, subjectArea, courseNumber, 1, 100, "true");
+                    "?quarter=%s&subjectCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                    quarter, subjectArea, courseId, 1, 100, "true");
             url = CURRICULUM_ENDPOINT + params;
         }
 

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -92,7 +92,6 @@ public class UCSBCurriculumService {
 
         String url = null;
 
-        // if (courseId.equals("")){
         if (courseNumber.equals("")){
             String params = String.format(
                 "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
@@ -117,7 +116,7 @@ public class UCSBCurriculumService {
                         "?quarter=%s&subjectCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
                         quarter, subjectArea, courseId, 1, 100, "true");
                 url = CURRICULUM_ENDPOINT + params;
-        }
+            }
         }
 
         log.info("url=" + url);

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -62,7 +62,23 @@ public class UCSBCurriculumService {
 
     public static final String ALL_SECTIONS_ENDPOINT = "https://api.ucsb.edu/academics/curriculums/v3/classes/{quarter}/{enrollcode}";
 
-    public String getJSON(String subjectArea, String quarter, String courseLevel) {
+    public String makeFormattedCourseId(String subjectArea, String courseNumber) {
+        String[] nums = courseNumber.split("[a-zA-Z]+");
+        String[] suffs = courseNumber.split("[0-9]+");
+        if (suffs.length < 2) { // no suffix
+            return
+                  String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+                + String.format( "%3s" , nums[0]                    ) // '  8'
+            ;
+        }
+        return
+              String.format( "%-8s", subjectArea                ) // 'CMPSC   '
+            + String.format( "%3s" , nums[0]                    ) // '  8'
+            + String.format( "%-2s", suffs[1]                   ) // 'A '
+        ;
+    }
+
+    public String getJSON(String subjectArea, String quarter, String courseLevel, String courseNumber) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
@@ -73,14 +89,14 @@ public class UCSBCurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String params = String.format(
-                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
-                subjectArea, courseLevel, 1, 100, "true");
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseNumber=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, courseLevel, courseNumber, 1, 100, "true");
         String url = CURRICULUM_ENDPOINT + params;
 
         if (courseLevel.equals("A")) {
             params = String.format(
-                    "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
-                    quarter, subjectArea, 1, 100, "true");
+                    "?quarter=%s&subjectCode=%s&courseNumber=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                    quarter, subjectArea, courseNumber, 1, 100, "true");
             url = CURRICULUM_ENDPOINT + params;
         }
 
@@ -101,17 +117,17 @@ public class UCSBCurriculumService {
         return retVal;
     }
 
-    public List<ConvertedSection> getConvertedSections(String subjectArea, String quarter, String courseLevel)
+    public List<ConvertedSection> getConvertedSections(String subjectArea, String quarter, String courseLevel, String courseNumber)
             throws JsonProcessingException {
-        String json = getJSON(subjectArea, quarter, courseLevel);
+        String json = getJSON(subjectArea, quarter, courseLevel, courseNumber);
         CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
         List<ConvertedSection> result = coursePage.convertedSections();       
         return result;
     }
 
-    public String getSectionJSON(String subjectArea, String quarter, String courseLevel)
+    public String getSectionJSON(String subjectArea, String quarter, String courseLevel, String courseNumber)
         throws JsonProcessingException {
-        List<ConvertedSection> l = getConvertedSections(subjectArea, quarter, courseLevel);
+        List<ConvertedSection> l = getConvertedSections(subjectArea, quarter, courseLevel, courseNumber);
         
         String arrayToJson = objectMapper.writeValueAsString(l);
     

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -40,14 +40,14 @@ public class UCSBCurriculumControllerTests {
 
     @MockBean
     private UCSBCurriculumService ucsbCurriculumService;
-
+    
     @Test
     public void test_search() throws Exception {
 
-        String expectedResult = "{expectedJSONResult}";
-        String urlTemplate = "/api/public/basicsearch?qtr=%s&dept=%s&level=%s";
-        String url = String.format(urlTemplate, "20204", "CMPSC", "L");
-        when(ucsbCurriculumService.getJSON(any(String.class), any(String.class), any(String.class)))
+        String expectedResult = "{expectedJSONCourseDescriptionResult}";
+        String urlTemplate = "/api/public/basicsearch?qtr=%s&dept=%s&level=%s&courseNumber=%s";
+        String url = String.format(urlTemplate, "20204", "CMPSC", "L", "16");
+        when(ucsbCurriculumService.getJSONCourseDescription(any(String.class), any(String.class), any(String.class), any(String.class)))
                 .thenReturn(expectedResult);
 
         MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -74,6 +74,87 @@ public class UCSBCurriculumServiceTests {
     }
 
     @Test
+    public void test_getJSONCourseDescription_success() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
+        String courseNumber = "16";
+        String courseId = "CMPSC%20%20%20%2016";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, courseId, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, level, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSONCourseDescription_success_WithoutSuffix() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
+        String courseNumber = "24";
+        String courseId = "CMPSC%20%20%20%2024";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, courseId, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, level, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSONCourseDescription_success_WithSuffix() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
+        String courseNumber = "130A";
+        String courseId = "CMPSC%20%20%20130A%20";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, courseId, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, level, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
     public void test_getJSONbyQtrEnrollCd_success() throws Exception {
         String expectedResult = PersonalSectionsFixtures.ONE_COURSE;
 
@@ -122,6 +203,88 @@ public class UCSBCurriculumServiceTests {
     }
 
     @Test
+    public void test_getJSONCourseDescription_success_level_A() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+
+        String level = "A";
+        String courseNumber = "16";
+        String courseId = "CMPSC%20%20%20%2016";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, subjectArea, courseId, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, level, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSONCourseDescription_success_level_empty() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+
+        String courseLevel = "L";
+        String courseNumber = "";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, subjectArea, courseLevel, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, courseLevel, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSONCourseDescription_success_level_empty_A() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+
+        String courseLevel = "A";
+        String courseNumber = "";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, subjectArea, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, courseLevel, courseNumber);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
     public void test_getJSON_exception() throws Exception {
         String expectedResult = "{\"error\": \"401: Unauthorized\"}";
 
@@ -145,6 +308,36 @@ public class UCSBCurriculumServiceTests {
                 .andRespond(withUnauthorizedRequest());
 
         String result = ucs.getJSON(subjectArea, quarter, level);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSONCourseDescription_exception() throws Exception {
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(HttpClientErrorException.class);
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
+        String courseNumber = "16";
+        String courseId = "CMPSC%20%20%20%2016";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, courseId, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withUnauthorizedRequest());
+
+        String result = ucs.getJSONCourseDescription(subjectArea, quarter, level, courseNumber);
 
         assertEquals(expectedResult, result);
     }


### PR DESCRIPTION
In this pull request, I added the course number as a search option to the course description search page. This is similar to the course history search. If you don't input a course number it will just list all the courses (+ their descriptions) for the selected subject area.

Closes #20 

Before:
<img width="1379" alt="Screenshot 2023-05-31 at 10 13 32 PM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/fad7f78e-14ed-4b0c-a7fe-61ad78534569">

After:
<img width="1382" alt="Screenshot 2023-05-31 at 10 05 52 PM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/18966b58-54fb-41cf-80f5-39b5984568ee">


