### PR TITLE
bs - reorder personal schedules nav bar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -15,7 +15,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
       }
       <Navbar expand="xl" variant="dark" className="color-nav" sticky="top" data-testid="AppNavbar">
         <Container >
-        <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginLeft: 5, marginRight: 10}} />
+        <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginRight: 10}} />
           <Navbar.Brand as={Link} to="/">
             UCSB Courses Search
           </Navbar.Brand>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -48,25 +48,15 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               )
             }
           </Nav>
-
-            <Nav className="mr-auto">
-              {
-                hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="PSCourse" id="appnavbar-courses-dropdown" data-testid="appnavbar-courses-dropdown" >
-                    <NavDropdown.Item href="/courses/list" data-testid="appnavbar-courses-list">List</NavDropdown.Item>
-                    <NavDropdown.Item href="/courses/create" data-testid="appnavbar-courses-create">Create</NavDropdown.Item>
-                  </NavDropdown>
-                )
-              }
-            </Nav>
-
         
             <Nav className="mr-auto">
               {
                 hasRole(currentUser, "ROLE_USER") && (
-                  <NavDropdown title="PersonalSchedules" id="appnavbar-personalschedules-dropdown" data-testid="appnavbar-personalschedules-dropdown" >
-                    <NavDropdown.Item href="/personalschedules/list" data-testid="appnavbar-personalschedules-list">List</NavDropdown.Item>
-                    <NavDropdown.Item href="/personalschedules/create" data-testid="appnavbar-personalschedules-create">Create</NavDropdown.Item>
+                  <NavDropdown title="Personal Schedules" id="appnavbar-personalschedules-dropdown" data-testid="appnavbar-personalschedules-dropdown" >
+                    <NavDropdown.Item href="/personalschedules/create" data-testid="appnavbar-personalschedules-create">Create Schedule</NavDropdown.Item>
+                    <NavDropdown.Item href="/courses/create" data-testid="appnavbar-courses-create">Add Course</NavDropdown.Item>
+                    <NavDropdown.Item href="/courses/list" data-testid="appnavbar-courses-list">All Courses</NavDropdown.Item>
+                    <NavDropdown.Item href="/personalschedules/list" data-testid="appnavbar-personalschedules-list">All Schedules</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -15,7 +15,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
       }
       <Navbar expand="xl" variant="dark" className="color-nav" sticky="top" data-testid="AppNavbar">
         <Container >
-        <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginRight: 10}} />
+        <img data-testid="AppNavbarImage" src={headerImg} alt="" style={{width: 80, height: 80, marginLeft: 5, marginRight: 10}} />
           <Navbar.Brand as={Link} to="/">
             UCSB Courses Search
           </Navbar.Brand>

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesCreatePage.js
@@ -50,7 +50,7 @@ export default function PersonalSchedulesCreatePage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create New PersonalSchedule</h1>
+        <h1>Create New Personal Schedule</h1>
 
         <PersonalScheduleForm submitAction={onSubmit} />
 

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -36,7 +36,7 @@ export default function PersonalSchedulesDetailsPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>PersonalSchedules Details</h1>
+        <h1>Personal Schedules Details</h1>
         {personalSchedule &&
                 <PersonalSchedulesTable personalSchedules={[personalSchedule]} showButtons={false} />
             }

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -5,7 +5,7 @@ export default function PersonalSchedulesEditPage() {
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>PersonalSchedules</h1>
+                <h1>Personal Schedules</h1>
                 <p>
                     This is where the edit page will go
                 </p>

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
@@ -20,7 +20,7 @@ export default function PersonalSchedulesIndexPage() {
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>PersonalSchedules</h1>
+                <h1>Personal Schedules</h1>
                 <PersonalSchedulesTable personalSchedules={personalSchedules} currentUser={currentUser} />
             </div>
         </BasicLayout>

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -144,30 +144,6 @@ describe("AppNavbar tests", () => {
         expect(screen.queryByTestId(/AppNavbarLocalhost/i)).toBeNull();
     });
 
-    test("renders the Courses menu correctly", async () => {
-        const currentUser = currentUserFixtures.userOnly;
-        const systemInfo = systemInfoFixtures.showingBoth;
-
-        const doLogin = jest.fn();
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        expect(await screen.findByTestId("appnavbar-courses-dropdown")).toBeInTheDocument();
-        const dropdown = screen.getByTestId("appnavbar-courses-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-
-        expect(await screen.findByTestId("appnavbar-courses-list")).toBeInTheDocument();
-        expect(screen.getByTestId(/appnavbar-courses-create/)).toBeInTheDocument();
-    });
-
     test("renders the PersonalSchedules menu correctly", async () => {
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
@@ -190,6 +166,9 @@ describe("AppNavbar tests", () => {
 
         expect(await screen.findByTestId("appnavbar-personalschedules-list")).toBeInTheDocument();
         expect(screen.getByTestId(/appnavbar-personalschedules-create/)).toBeInTheDocument();
+
+        expect(await screen.findByTestId("appnavbar-courses-list")).toBeInTheDocument();
+        expect(screen.getByTestId(/appnavbar-courses-create/)).toBeInTheDocument();
     });
 
     test("renders the Course Description menu correctly", async () => {

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -144,7 +144,7 @@ describe("PersonalSchedulesDetailsPage tests", () => {
             </QueryClientProvider>
         );
         await waitFor(()=>{
-             expect(screen.getByText("PersonalSchedules Details")).toBeInTheDocument();
+             expect(screen.getByText("Personal Schedules Details")).toBeInTheDocument();
         });
         await waitFor(()=>{
             expect(screen.getByText("Sections in Personal Schedule")).toBeInTheDocument();


### PR DESCRIPTION
In this pull request I combined the personal schedules and PS Course dropdown into one dropdown on the nav bar. I renamed the dropdown options and fixed the spacing in the titles of the PS pages. I also updated the frontend tests that test these files.

storybook link: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-4/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in

Closes: #29 

Before:
![Screen Shot 2023-06-02 at 12 17 53 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/63817b92-3338-4623-b613-654c72a2e20f)

![Screen Shot 2023-06-02 at 12 17 58 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/ce6514d0-42d2-4915-8fb0-99cb01564699)

![Screen Shot 2023-06-02 at 12 18 03 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/7fa895c7-da77-4c63-b020-84ff5af105d0)

After:
![Screenshot 2023-06-02 at 12 17 40 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/9b5f564a-61ad-4ac6-a46c-1b159034e2eb)
