### PR TITLE
bs - update dokku deployment links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Users with a Google Account can also store past, current or future schedules of 
 
 | Type | Link       | 
 |------|------------|
-| prod | <https://proj-courses.dokku-00.cs.ucsb.edu/> | 
-| qa | <https://proj-courses-qa.dokku-00.cs.ucsb.edu/>  | 
+| prod | <https://proj-courses.dokku-12.cs.ucsb.edu/> | 
+| qa | <https://proj-courses-qa.dokku-12.cs.ucsb.edu/>  | 
 
 
 # Setup before running application


### PR DESCRIPTION
In this PR I updated the dokky deployment links in the README to match the group's correct QA and PROD deployments. Changed from "00" to "12".

Closes: #31 