### PR TITLE
bs - fixed bug with image not showing up on localhost

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
In this PR I fixed a bug with the frontend proxy controller so that the image in the nav bar displays properly in localhost. 

Closes: #40 

Before: 
![Screen Shot 2023-06-05 at 12 42 21 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/03f20498-ecde-4d0c-9826-c2dd77b963f8)

After:
<img width="1419" alt="Screenshot 2023-06-05 at 12 40 40 PM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/81649257/3c852c70-230c-4608-b707-e9e1c4a0ca8b">

Based of this PR: https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-3/pull/34
