### PR TITLE
kt - remove quarter for sections in basic search 

### DIFF
--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -53,8 +53,9 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")
+                    ) : cell.isPlaceholder ? null : (
+                    cell.render('Cell')
                     )
-                    : cell.render('Cell')
                     }
                     <>
                     


### PR DESCRIPTION
In this PR, I changed the Basic Search Table so that the quarter would not display for sections since the repeated quarter is redundant with an aggregated lecture/section view.

closes #46 

Before screenshot:
![Screen Shot 2023-06-05 at 4 40 14 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/126eba96-c1b2-48b3-bc02-a11a9c3f1268)

After screenshot:
![Screen Shot 2023-06-05 at 4 39 54 PM](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-4/assets/78584763/9b4443c4-6263-4f9d-9bf0-4a5c21197109)

storyboard before link: https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-4/storybook/?path=/docs/components-sections-sectionstable--empty

storyboard after link: 