### PR TITLE
bs - Update 34-frontend-main-mutation-testing.yml

### DIFF
--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
       - uses: szenius/set-timezone@v1.2


### PR DESCRIPTION
In this pull request I extended the time for workflow 34 because it timed out in main. Changed from 40 to 60 minutes.