### PR TITLE
bs - Update 34-frontend-main-mutation-testing.yml

### DIFF
--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 80
 
     steps:
       - uses: szenius/set-timezone@v1.2


### PR DESCRIPTION
Update workflow because timed out. Changed to 80 minutes.